### PR TITLE
Feat/#3 주문 CRUD 및 배달 기능 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/prgrms/coffee_order_be/CoffeeOrderBeApplication.java
+++ b/src/main/java/org/prgrms/coffee_order_be/CoffeeOrderBeApplication.java
@@ -2,7 +2,9 @@ package org.prgrms.coffee_order_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class CoffeeOrderBeApplication {
 

--- a/src/main/java/org/prgrms/coffee_order_be/config/SwaggerConfig.java
+++ b/src/main/java/org/prgrms/coffee_order_be/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package org.prgrms.coffee_order_be.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("API 문서")
+                .description("잘못된 부분이나 오류 발생 시 말씀해주세요.");
+
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement addSecurityItem = new SecurityRequirement();
+        addSecurityItem.addList("Bearer Token");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("Bearer Token", bearerAuth))
+                .addSecurityItem(addSecurityItem)
+                .info(info);
+    }
+
+}

--- a/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
+++ b/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
@@ -1,0 +1,33 @@
+package org.prgrms.coffee_order_be.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.prgrms.coffee_order_be.model.dto.request.CreateOderReq;
+import org.prgrms.coffee_order_be.model.entity.OrderItem;
+import org.prgrms.coffee_order_be.model.service.OrderService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Order" , description = "Order 관련 API 모음")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/order")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @Operation(summary = "주문 생성")
+    @PostMapping
+    public ResponseEntity<?> createOrder(@RequestBody @Valid CreateOderReq req){
+        List<OrderItem> resp = orderService.createOrder(req);
+
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
+++ b/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
@@ -4,15 +4,17 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
 import org.prgrms.coffee_order_be.model.dto.request.CreateOderReq;
+import org.prgrms.coffee_order_be.model.dto.request.UpdateOrderReq;
 import org.prgrms.coffee_order_be.model.dto.response.GetOrdersRes;
+import org.prgrms.coffee_order_be.model.entity.Order;
 import org.prgrms.coffee_order_be.model.entity.OrderItem;
 import org.prgrms.coffee_order_be.model.service.OrderService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Tag(name = "Order" , description = "Order 관련 API 모음")
 @RestController
@@ -32,8 +34,15 @@ public class OrderController {
 
     @Operation(summary = "이메일로 주문 조회")
     @GetMapping
-    public ResponseEntity<List<GetOrdersRes>> getOrders(@RequestParam("email") String email){
-        List<GetOrdersRes> resp = orderService.getOrders(email);
+    public ResponseEntity<List<GetOrdersRes>> getOrder(@RequestParam("email") String email){
+        List<GetOrdersRes> resp = orderService.getOrder(email);
+        return ResponseEntity.ok(resp);
+    }
+
+    @Operation(summary = "주문 수정")
+    @PutMapping("/{id}")
+    public ResponseEntity<Order> updateOrder(@PathVariable("id") UUID uuid, @RequestBody @Valid UpdateOrderReq req){
+        Order resp = orderService.updateOrder(uuid, req);
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
+++ b/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
@@ -4,14 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
 import org.prgrms.coffee_order_be.model.dto.request.CreateOderReq;
+import org.prgrms.coffee_order_be.model.dto.response.GetOrdersRes;
 import org.prgrms.coffee_order_be.model.entity.OrderItem;
 import org.prgrms.coffee_order_be.model.service.OrderService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,9 +24,17 @@ public class OrderController {
 
     @Operation(summary = "주문 생성")
     @PostMapping
-    public ResponseEntity<?> createOrder(@RequestBody @Valid CreateOderReq req){
+    public ResponseEntity<List<OrderItem>> createOrder(@RequestBody @Valid CreateOderReq req){
         List<OrderItem> resp = orderService.createOrder(req);
 
         return ResponseEntity.ok(resp);
     }
+
+    @Operation(summary = "이메일로 주문 조회")
+    @GetMapping
+    public ResponseEntity<List<GetOrdersRes>> getOrders(@RequestParam("email") String email){
+        List<GetOrdersRes> resp = orderService.getOrders(email);
+        return ResponseEntity.ok(resp);
+    }
+
 }

--- a/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
+++ b/src/main/java/org/prgrms/coffee_order_be/controller/OrderController.java
@@ -46,4 +46,10 @@ public class OrderController {
         return ResponseEntity.ok(resp);
     }
 
+    @Operation(summary = "주문 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteOrder(@PathVariable("id") UUID uuid){
+        String resp = orderService.deleteOrder(uuid);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/src/main/java/org/prgrms/coffee_order_be/controller/ProductController.java
+++ b/src/main/java/org/prgrms/coffee_order_be/controller/ProductController.java
@@ -1,5 +1,7 @@
 package org.prgrms.coffee_order_be.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.coffee_order_be.model.dto.ProductDto;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Product" , description = "Product 관련 API 모음")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/product")
@@ -20,24 +23,28 @@ public class ProductController {
 
     private final ProductService productService;
 
+    @Operation(summary = "상품 생성")
     @PostMapping
     public ResponseEntity<ProductDto> createProduct(@RequestBody @Valid CreateProductReq req){
         ProductDto resp = productService.createProduct(req);
         return ResponseEntity.ok(resp);
     }
 
+    @Operation(summary = "상품 리스트 조회")
     @GetMapping
     public ResponseEntity<List<GetProductsRes>> getProducts(){
         List<GetProductsRes> resp = productService.getProducts();
         return ResponseEntity.ok(resp);
     }
 
+    @Operation(summary = "상품 상세 조회")
     @GetMapping("/{id}")
     public ResponseEntity<ProductDto> getProduct(@PathVariable(name = "id") UUID uuid){
         ProductDto resp = productService.getProduct(uuid);
         return ResponseEntity.ok(resp);
     }
 
+    @Operation(summary = "상품 수정")
     @PutMapping("/{id}")
     public ResponseEntity<ProductDto> updateProduct(@PathVariable(name = "id") UUID uuid,
                                                     @RequestBody @Valid UpdateProductReq req) {
@@ -45,6 +52,7 @@ public class ProductController {
         return ResponseEntity.ok(resp);
     }
 
+    @Operation(summary = "상품 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteProduct(@PathVariable(name = "id") UUID uuid){
         String resp = productService.deleteProduct(uuid);

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/OrderItemDto.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/OrderItemDto.java
@@ -1,0 +1,18 @@
+package org.prgrms.coffee_order_be.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderItemDto {
+
+    private String category;
+
+    private long price;
+
+    private int quantity;
+
+    private String productName;
+
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/OrderItemsDto.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/OrderItemsDto.java
@@ -1,0 +1,13 @@
+package org.prgrms.coffee_order_be.model.dto;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class OrderItemsDto {
+
+    private UUID productsUUID;
+
+    private int quantity;
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateOderReq.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateOderReq.java
@@ -1,5 +1,6 @@
 package org.prgrms.coffee_order_be.model.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.prgrms.coffee_order_be.model.entity.Order;
@@ -8,16 +9,16 @@ import java.util.List;
 
 @Getter
 public class CreateOderReq {
-    @NotNull
+    @NotBlank
     private List<OrderProductDto> orderItems;
 
-    @NotNull
+    @NotBlank
     private String email;
 
-    @NotNull
+    @NotBlank
     private String address;
 
-    @NotNull
+    @NotBlank
     private String postcode;
 
     public Order toOrder(){

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateOderReq.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateOderReq.java
@@ -2,7 +2,6 @@ package org.prgrms.coffee_order_be.model.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import org.prgrms.coffee_order_be.model.dto.OrderItemsDto;
 import org.prgrms.coffee_order_be.model.entity.Order;
 
 import java.util.List;
@@ -10,7 +9,7 @@ import java.util.List;
 @Getter
 public class CreateOderReq {
     @NotNull
-    private List<OrderItemsDto> orderItems;
+    private List<OrderProductDto> orderItems;
 
     @NotNull
     private String email;

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateOderReq.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateOderReq.java
@@ -1,0 +1,31 @@
+package org.prgrms.coffee_order_be.model.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.prgrms.coffee_order_be.model.dto.OrderItemsDto;
+import org.prgrms.coffee_order_be.model.entity.Order;
+
+import java.util.List;
+
+@Getter
+public class CreateOderReq {
+    @NotNull
+    private List<OrderItemsDto> orderItems;
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String address;
+
+    @NotNull
+    private String postcode;
+
+    public Order toOrder(){
+        return Order.builder()
+                .email(email)
+                .address(address)
+                .postcode(postcode)
+                .build();
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateProductReq.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/CreateProductReq.java
@@ -8,16 +8,16 @@ import org.prgrms.coffee_order_be.model.entity.Product;
 @Getter
 public class CreateProductReq {
 
-    @NotNull
+    @NotBlank
     private String productName;
 
-    @NotNull
+    @NotBlank
     private String category;
 
-    @NotNull
+    @NotBlank
     private long price;
 
-    @NotNull
+    @NotBlank
     private String description;
 
     public Product toProduct(){

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/OrderProductDto.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/OrderProductDto.java
@@ -1,11 +1,11 @@
-package org.prgrms.coffee_order_be.model.dto;
+package org.prgrms.coffee_order_be.model.dto.request;
 
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
-public class OrderItemsDto {
+public class OrderProductDto {
 
     private UUID productsUUID;
 

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/UpdateOrderReq.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/UpdateOrderReq.java
@@ -1,0 +1,14 @@
+package org.prgrms.coffee_order_be.model.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UpdateOrderReq {
+    @NotBlank
+    private String address;
+
+    @NotBlank
+    private String postcode;
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/request/UpdateProductReq.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/request/UpdateProductReq.java
@@ -1,13 +1,14 @@
 package org.prgrms.coffee_order_be.model.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class UpdateProductReq {
-    @NotNull
+    @NotBlank
     private long price;
 
-    @NotNull
+    @NotBlank
     private String description;
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/response/GetOrdersRes.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/response/GetOrdersRes.java
@@ -3,15 +3,23 @@ package org.prgrms.coffee_order_be.model.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
+import org.prgrms.coffee_order_be.model.entity.OrderStatus;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
 public class GetOrdersRes {
-    List<OrderItemDto> orderItemDtos;
+    private UUID uuid;
 
-    public GetOrdersRes(List<OrderItemDto> orderItemDtos) {
-        this.orderItemDtos = orderItemDtos;
+    private List<OrderItemDto> orderRes;
+
+    private OrderStatus orderStatus;
+
+    public GetOrdersRes(UUID uuid, List<OrderItemDto> orderRes, OrderStatus orderStatus) {
+        this.uuid = uuid;
+        this.orderRes = orderRes;
+        this.orderStatus = orderStatus;
     }
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/response/GetOrdersRes.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/response/GetOrdersRes.java
@@ -1,0 +1,17 @@
+package org.prgrms.coffee_order_be.model.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class GetOrdersRes {
+    List<OrderItemDto> orderItemDtos;
+
+    public GetOrdersRes(List<OrderItemDto> orderItemDtos) {
+        this.orderItemDtos = orderItemDtos;
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/dto/response/GetOrdersRes.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/dto/response/GetOrdersRes.java
@@ -17,9 +17,15 @@ public class GetOrdersRes {
 
     private OrderStatus orderStatus;
 
-    public GetOrdersRes(UUID uuid, List<OrderItemDto> orderRes, OrderStatus orderStatus) {
+    private String address;
+
+    private String postcode;
+
+    public GetOrdersRes(UUID uuid, List<OrderItemDto> orderRes, OrderStatus orderStatus, String address, String postcode) {
         this.uuid = uuid;
         this.orderRes = orderRes;
         this.orderStatus = orderStatus;
+        this.address = address;
+        this.postcode = postcode;
     }
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
@@ -44,4 +44,11 @@ public class Order {
         this.postcode = postcode;
         this.orderStatus = OrderStatus.ORDER_COMPLETED;
     }
+
+    public Order update(String address, String postcode){
+        this.address = address;
+        this.postcode = postcode;
+
+        return this;
+    }
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "product_id", columnDefinition = "BINARY(16)")
+    @Column(name = "order_id")
     private UUID id;
 
     private String email;

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -27,6 +28,7 @@ public class Order {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "order_status")
+    @Setter
     private OrderStatus orderStatus;
 
     @Column(name = "created_at")

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/Order.java
@@ -1,0 +1,47 @@
+package org.prgrms.coffee_order_be.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity(name = "orders")
+@Getter
+@NoArgsConstructor
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "product_id", columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    private String email;
+
+    private String address;
+
+    private String postcode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status")
+    private OrderStatus orderStatus;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Order(String email, String address, String postcode) {
+        this.email = email;
+        this.address = address;
+        this.postcode = postcode;
+        this.orderStatus = OrderStatus.ORDER_COMPLETED;
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/OrderItem.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/OrderItem.java
@@ -1,0 +1,50 @@
+package org.prgrms.coffee_order_be.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "order_items")
+@Getter
+@NoArgsConstructor
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private long id;
+
+    private String category;
+
+    private long price;
+
+    private int quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Product product;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public OrderItem(String category, long price, int quantity, Order order, Product product) {
+        this.category = category;
+        this.price = price;
+        this.quantity = quantity;
+        this.order = order;
+        this.product = product;
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/OrderItem.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/OrderItem.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +17,7 @@ public class OrderItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "product_id")
+    @Column(name = "seq")
     private long id;
 
     private String category;
@@ -26,9 +27,11 @@ public class OrderItem {
     private int quantity;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
     private Order order;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
     private Product product;
 
     @Column(name = "created_at")
@@ -46,5 +49,14 @@ public class OrderItem {
         this.quantity = quantity;
         this.order = order;
         this.product = product;
+    }
+
+    public OrderItemDto toDto(){
+        return OrderItemDto.builder()
+                .productName(product.getProductName())
+                .quantity(quantity)
+                .category(category)
+                .price(price)
+                .build();
     }
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/entity/OrderStatus.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/entity/OrderStatus.java
@@ -1,0 +1,5 @@
+package org.prgrms.coffee_order_be.model.entity;
+
+public enum OrderStatus {
+    ORDER_COMPLETED ,IN_DELIVERY, DELIVERY_COMPLETED
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderItemRepository.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderItemRepository.java
@@ -1,8 +1,12 @@
 package org.prgrms.coffee_order_be.model.repository;
 
+import org.prgrms.coffee_order_be.model.entity.Order;
 import org.prgrms.coffee_order_be.model.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    List<OrderItem> findAllByOrder(Order order);
 
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderItemRepository.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderItemRepository.java
@@ -1,0 +1,8 @@
+package org.prgrms.coffee_order_be.model.repository;
+
+import org.prgrms.coffee_order_be.model.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
@@ -3,7 +3,9 @@ package org.prgrms.coffee_order_be.model.repository;
 import org.prgrms.coffee_order_be.model.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+    List<Order> findAllByEmail(String email);
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
@@ -1,11 +1,16 @@
 package org.prgrms.coffee_order_be.model.repository;
 
 import org.prgrms.coffee_order_be.model.entity.Order;
+import org.prgrms.coffee_order_be.model.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
     List<Order> findAllByEmailOrderByCreatedAtDesc(String email);
+
+    @Query("SELECT o FROM orders o WHERE o.orderStatus =:orderStatus")
+    List<Order> findAllByOrderStatus(OrderStatus orderStatus);
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
-    List<Order> findAllByEmail(String email);
+    List<Order> findAllByEmailOrderByCreatedAtDesc(String email);
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package org.prgrms.coffee_order_be.model.repository;
+
+import org.prgrms.coffee_order_be.model.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/DeliveryService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/DeliveryService.java
@@ -1,0 +1,26 @@
+package org.prgrms.coffee_order_be.model.service;
+
+import lombok.RequiredArgsConstructor;
+import org.prgrms.coffee_order_be.model.entity.Order;
+import org.prgrms.coffee_order_be.model.entity.OrderStatus;
+import org.prgrms.coffee_order_be.model.repository.OrderRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final OrderRepository orderRepository;
+
+    @Scheduled(cron = "0 0 14 * * *", zone = "Asia/Seoul")
+    public void delivery(){
+        List<Order> orderList = orderRepository.findAllByOrderStatus(OrderStatus.ORDER_COMPLETED);
+        for (Order order : orderList) {
+            order.setOrderStatus(OrderStatus.IN_DELIVERY);
+        }
+        orderRepository.saveAll(orderList);
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -1,12 +1,14 @@
 package org.prgrms.coffee_order_be.model.service;
 
 import lombok.RequiredArgsConstructor;
+import org.prgrms.coffee_order_be.model.dto.request.UpdateOrderReq;
 import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
 import org.prgrms.coffee_order_be.model.dto.request.OrderProductDto;
 import org.prgrms.coffee_order_be.model.dto.request.CreateOderReq;
 import org.prgrms.coffee_order_be.model.dto.response.GetOrdersRes;
 import org.prgrms.coffee_order_be.model.entity.Order;
 import org.prgrms.coffee_order_be.model.entity.OrderItem;
+import org.prgrms.coffee_order_be.model.entity.OrderStatus;
 import org.prgrms.coffee_order_be.model.entity.Product;
 import org.prgrms.coffee_order_be.model.repository.OrderItemRepository;
 import org.prgrms.coffee_order_be.model.repository.OrderRepository;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -47,19 +50,23 @@ public class OrderService {
         return orderItems;
     }
 
-    public List<GetOrdersRes> getOrders(String email){
+    public List<GetOrdersRes> getOrder(String email){
         List<Order> orders = orderRepository.findAllByEmail(email);
+        if(orders.isEmpty())
+            throw new RuntimeException("주문 내역이 없습니다.");
+
         List<GetOrdersRes> getOrdersResList = new ArrayList<>();
 
         for(Order order : orders){
             List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
-            List<OrderItemDto> orderItemDtos = orderItems.stream().map(OrderItem::toDto).toList();
-            GetOrdersRes getOrdersRes = new GetOrdersRes(orderItemDtos);
+            List<OrderItemDto> orderRes = orderItems.stream().map(OrderItem::toDto).toList();
+            GetOrdersRes getOrdersRes = new GetOrdersRes(order.getId(), orderRes, order.getOrderStatus());
 
-            if(!orderItemDtos.isEmpty())
+            if(!orderRes.isEmpty())
                 getOrdersResList.add(getOrdersRes);
         }
 
         return getOrdersResList;
     }
+
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -60,7 +60,7 @@ public class OrderService {
         for(Order order : orders){
             List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
             List<OrderItemDto> orderRes = orderItems.stream().map(OrderItem::toDto).toList();
-            GetOrdersRes getOrdersRes = new GetOrdersRes(order.getId(), orderRes, order.getOrderStatus());
+            GetOrdersRes getOrdersRes = new GetOrdersRes(order.getId(), orderRes, order.getOrderStatus(), order.getAddress(), order.getPostcode());
 
             if(!orderRes.isEmpty())
                 getOrdersResList.add(getOrdersRes);

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -51,7 +51,7 @@ public class OrderService {
     }
 
     public List<GetOrdersRes> getOrder(String email){
-        List<Order> orders = orderRepository.findAllByEmail(email);
+        List<Order> orders = orderRepository.findAllByEmailOrderByCreatedAtDesc(email);
         if(orders.isEmpty())
             throw new RuntimeException("주문 내역이 없습니다.");
 

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -1,8 +1,10 @@
 package org.prgrms.coffee_order_be.model.service;
 
 import lombok.RequiredArgsConstructor;
-import org.prgrms.coffee_order_be.model.dto.OrderItemsDto;
+import org.prgrms.coffee_order_be.model.dto.OrderItemDto;
+import org.prgrms.coffee_order_be.model.dto.request.OrderProductDto;
 import org.prgrms.coffee_order_be.model.dto.request.CreateOderReq;
+import org.prgrms.coffee_order_be.model.dto.response.GetOrdersRes;
 import org.prgrms.coffee_order_be.model.entity.Order;
 import org.prgrms.coffee_order_be.model.entity.OrderItem;
 import org.prgrms.coffee_order_be.model.entity.Product;
@@ -13,7 +15,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class OrderService {
         Order order = req.toOrder();
         List<OrderItem> orderItems = new ArrayList<>();
 
-        for(OrderItemsDto orderItem : req.getOrderItems()){
+        for(OrderProductDto orderItem : req.getOrderItems()){
             Product product = productRepository.findById(orderItem.getProductsUUID())
                     .orElseThrow(() -> new RuntimeException("상품이 존재하지 않습니다."));
 
@@ -44,5 +45,21 @@ public class OrderService {
         orderItemRepository.saveAll(orderItems);
 
         return orderItems;
+    }
+
+    public List<GetOrdersRes> getOrders(String email){
+        List<Order> orders = orderRepository.findAllByEmail(email);
+        List<GetOrdersRes> getOrdersResList = new ArrayList<>();
+
+        for(Order order : orders){
+            List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
+            List<OrderItemDto> orderItemDtos = orderItems.stream().map(OrderItem::toDto).toList();
+            GetOrdersRes getOrdersRes = new GetOrdersRes(orderItemDtos);
+
+            if(!orderItemDtos.isEmpty())
+                getOrdersResList.add(getOrdersRes);
+        }
+
+        return getOrdersResList;
     }
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -69,4 +69,18 @@ public class OrderService {
         return getOrdersResList;
     }
 
+
+    public Order updateOrder(UUID uuid, UpdateOrderReq req){
+        Order order = orderRepository.findById(uuid)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 주문 입니다."));
+
+        if(order.getOrderStatus() != OrderStatus.ORDER_COMPLETED)
+            throw new RuntimeException("배달이 진행 중이므로 상담원에게 전화 연락 부탁드립니다.");
+
+        order.update(req.getAddress(), req.getPostcode());
+        orderRepository.save(order);
+
+        return order;
+    }
+
 }

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -1,0 +1,48 @@
+package org.prgrms.coffee_order_be.model.service;
+
+import lombok.RequiredArgsConstructor;
+import org.prgrms.coffee_order_be.model.dto.OrderItemsDto;
+import org.prgrms.coffee_order_be.model.dto.request.CreateOderReq;
+import org.prgrms.coffee_order_be.model.entity.Order;
+import org.prgrms.coffee_order_be.model.entity.OrderItem;
+import org.prgrms.coffee_order_be.model.entity.Product;
+import org.prgrms.coffee_order_be.model.repository.OrderItemRepository;
+import org.prgrms.coffee_order_be.model.repository.OrderRepository;
+import org.prgrms.coffee_order_be.model.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ProductRepository productRepository;
+
+    public List<OrderItem> createOrder(CreateOderReq req){
+        Order order = req.toOrder();
+        List<OrderItem> orderItems = new ArrayList<>();
+
+        for(OrderItemsDto orderItem : req.getOrderItems()){
+            Product product = productRepository.findById(orderItem.getProductsUUID())
+                    .orElseThrow(() -> new RuntimeException("상품이 존재하지 않습니다."));
+
+            orderItems.add(OrderItem.builder()
+                    .product(product)
+                    .order(order)
+                    .quantity(orderItem.getQuantity())
+                    .category(product.getCategory())
+                    .price(product.getPrice() * orderItem.getQuantity())
+                    .build());
+        }
+
+        orderRepository.save(order);
+        orderItemRepository.saveAll(orderItems);
+
+        return orderItems;
+    }
+}

--- a/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
+++ b/src/main/java/org/prgrms/coffee_order_be/model/service/OrderService.java
@@ -83,4 +83,16 @@ public class OrderService {
         return order;
     }
 
+    public String deleteOrder(UUID uuid){
+        Order order = orderRepository.findById(uuid)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 주문 입니다."));
+
+        if(order.getOrderStatus() != OrderStatus.ORDER_COMPLETED)
+            throw new RuntimeException("배달이 진행 중이므로 삭제가 불가능합니다.");
+
+        orderRepository.delete(order);
+
+        return "Success delete";
+    }
+
 }


### PR DESCRIPTION
2. 주문 CRUD
    - [x]  주문 생성 기능
        - `order_items`, `email, address`, `postcode`으로 주문을 생성할 수 있다.
            - `order_items`는 `product_id`, `quantity`으로 구성된다.
    - [x]  주문 조회 기능
        - `email` 값으로 주문 리스트를 조회할 수 있다.
        - `주문 식별` 값으로 단건 주문을 조회할 수 있다.
    - [x]  주문 수정 기능
        - `주문 식별값`으로 주문을 수정할 수 있다.
        - 수정 항목: `address`,  `postcode`
            - “주문 완료” 인 경우에만 주문 수정 가능
    - [x]  주문 삭제 기능
        - `주문 식별값`으로 주문을 삭제할 수 있다.
        - 주문 상태 : “주문 완료” , “배송 시작”
            - “주문 완료” 인 경우에만 주문 삭제 가능
    
    - [x]  주문 완료인 주문을 배송 시작 상태로 변경할 수 있다.
        - 14시에 주문 완료 상태의 주문을 배송 시작 상태로 변경한다.